### PR TITLE
Fix default export for WeatherCard

### DIFF
--- a/src/components/WeatherCard.tsx
+++ b/src/components/WeatherCard.tsx
@@ -67,4 +67,6 @@ export const WeatherCard = ({ data }: WeatherCardProps) => {
       </div>
     </div>
   );
-}; 
+};
+
+export default WeatherCard;


### PR DESCRIPTION
## Summary
- ensure WeatherCard is exported as default

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877afee43548327be4e3d2f2ff08a01