### PR TITLE
Implement DWD weather service

### DIFF
--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -7,7 +7,7 @@ export interface WeatherData {
   windDirection: number;
   precipitation: number;
   cloudCover: number;
-  provider: 'OpenWeatherMap' | 'OpenMeteo';
+  provider: 'OpenWeatherMap' | 'OpenMeteo' | 'DWD';
 }
 
 export interface WeatherForecast {
@@ -18,7 +18,7 @@ export interface WeatherForecast {
   precipitationAmount: number;
   windSpeed: number;
   windDirection: number;
-  provider: 'OpenWeatherMap' | 'OpenMeteo';
+  provider: 'OpenWeatherMap' | 'OpenMeteo' | 'DWD';
 }
 
 export interface WeatherStats {


### PR DESCRIPTION
## Summary
- implement `fetchDWDData` using Bright Sky API to retrieve DWD measurements
- extend `WeatherData` and `WeatherForecast` provider types with `DWD`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d5e37a58832788839c4a2cd77057