### PR TITLE
Add Jest setup and sample test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
@@ -15,4 +15,4 @@ const customJestConfig = {
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-module.exports = createJestConfig(customJestConfig); 
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,2 +1,3 @@
 // Learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom'; 
+import '@testing-library/jest-dom';
+

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^14.3.1",
+    "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.0",

--- a/src/__tests__/sample.test.tsx
+++ b/src/__tests__/sample.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+describe('Sample test', () => {
+  it('renders a confirmation message', () => {
+    render(<p>Hello from the testing stack!</p>);
+
+    expect(
+      screen.getByText(/hello from the testing stack!/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["jest", "@testing-library/jest-dom"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- point the Jest configuration at a TypeScript-based setup file that registers `@testing-library/jest-dom`
- add a smoke test that renders sample content with React Testing Library
- upgrade `@testing-library/react` and include Jest typings for TypeScript awareness

## Testing
- npm test *(fails: Jest is unavailable without installing dependencies in this offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8d755f7308327b6f791b933abdaa6