### PR TITLE
feat: add location comparison with unified weather APIs

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -1,11 +1,24 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import Page from '../page';
+import type { UnifiedCurrentResponse, UnifiedForecastResponse } from '@/types/unifiedWeather';
 
-// Mock the useWeatherData hook
-jest.mock('../../hooks/useWeatherData', () => ({
-  useWeatherData: () => ({
-    currentData: [
-      {
+const mockLocation = {
+  id: 'loc-1',
+  name: 'Berlin',
+  admin1: 'Berlin',
+  country: 'Germany',
+  latitude: 52.52,
+  longitude: 13.405
+};
+
+const currentResponse: UnifiedCurrentResponse = {
+  location: mockLocation,
+  providers: [
+    {
+      provider: 'OpenWeatherMap',
+      fromCache: false,
+      rateLimited: false,
+      data: {
         timestamp: '2024-01-01T12:00:00Z',
         temperature: 20,
         humidity: 60,
@@ -13,84 +26,121 @@ jest.mock('../../hooks/useWeatherData', () => ({
         windSpeed: 5,
         windDirection: 180,
         precipitation: 0,
-        cloudCover: 20,
-        provider: 'OpenMeteo'
+        cloudCover: 20
       }
-    ],
-    forecastData: [
-      {
-        date: '2024-01-01',
-        maxTemperature: 22,
-        minTemperature: 15,
-        precipitationProbability: 20,
-        precipitationAmount: 0.5,
-        windSpeed: 5,
-        windDirection: 180,
-        provider: 'OpenMeteo'
+    },
+    {
+      provider: 'OpenMeteo',
+      fromCache: true,
+      rateLimited: false,
+      data: {
+        timestamp: '2024-01-01T12:00:00Z',
+        temperature: 19,
+        humidity: 58,
+        pressure: 1012,
+        windSpeed: 4,
+        windDirection: 175,
+        precipitation: 0.2,
+        cloudCover: 30
       }
-    ],
-    isLoading: false,
-    error: null
-  })
+    }
+  ]
+};
+
+const forecastResponse: UnifiedForecastResponse = {
+  location: mockLocation,
+  providers: [
+    {
+      provider: 'OpenWeatherMap',
+      fromCache: false,
+      rateLimited: false,
+      data: [
+        {
+          date: '2024-01-02',
+          maxTemperature: 22,
+          minTemperature: 15,
+          precipitationProbability: 20,
+          precipitationAmount: 0.5,
+          windSpeed: 6,
+          windDirection: 180
+        }
+      ]
+    },
+    {
+      provider: 'OpenMeteo',
+      fromCache: false,
+      rateLimited: false,
+      data: [
+        {
+          date: '2024-01-02',
+          maxTemperature: 21,
+          minTemperature: 14,
+          precipitationProbability: 15,
+          precipitationAmount: 0.3,
+          windSpeed: 5,
+          windDirection: 170
+        }
+      ]
+    }
+  ]
+};
+
+const mockUseUnifiedWeather = jest.fn();
+
+jest.mock('@/hooks/useUnifiedWeather', () => ({
+  useUnifiedWeather: (...args: unknown[]) => mockUseUnifiedWeather(...args)
 }));
 
-describe('Page', () => {
-  it('renders weather dashboard', async () => {
+describe('Weather Dashboard Page', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockUseUnifiedWeather.mockReset();
+  });
+
+  it('shows empty state when no locations are selected', async () => {
+    mockUseUnifiedWeather.mockReturnValue({
+      current: {},
+      forecast: {},
+      loading: false,
+      errors: {},
+      rateLimited: false,
+      refetch: jest.fn()
+    });
+
     render(<Page />);
 
-    // Check if title is displayed
-    expect(screen.getByText('Weather Dashboard')).toBeInTheDocument();
-
-    // Check if weather cards are rendered
     await waitFor(() => {
-      expect(screen.getByText('OpenMeteo')).toBeInTheDocument();
+      expect(
+        screen.getByText('Select a city from the search results or your favorites to see the comparison.')
+      ).toBeInTheDocument();
     });
-
-    // Check if charts are rendered
-    expect(screen.getByText('Current Weather Comparison')).toBeInTheDocument();
-    expect(screen.getByText('Temperature Forecast')).toBeInTheDocument();
-    expect(screen.getByText('Precipitation Forecast Comparison')).toBeInTheDocument();
   });
 
-  it('displays loading state', () => {
-    // Mock loading state
-    jest.spyOn(require('../../hooks/useWeatherData'), 'useWeatherData').mockReturnValue({
-      currentData: [],
-      forecastData: [],
-      isLoading: true,
-      error: null
-    });
-
-    render(<Page />);
-
-    expect(screen.getByText('Loading weather data...')).toBeInTheDocument();
-  });
-
-  it('displays error state', () => {
-    // Mock error state
-    jest.spyOn(require('../../hooks/useWeatherData'), 'useWeatherData').mockReturnValue({
-      currentData: [],
-      forecastData: [],
-      isLoading: false,
-      error: 'Failed to fetch weather data'
+  it('renders weather information for selected locations', async () => {
+    localStorage.setItem('weather:selected', JSON.stringify([mockLocation]));
+    mockUseUnifiedWeather.mockReturnValue({
+      current: {
+        [mockLocation.id]: currentResponse
+      },
+      forecast: {
+        [mockLocation.id]: forecastResponse
+      },
+      loading: false,
+      errors: {
+        [mockLocation.id]: null
+      },
+      rateLimited: false,
+      refetch: jest.fn()
     });
 
     render(<Page />);
 
-    expect(screen.getByText('Error: Failed to fetch weather data')).toBeInTheDocument();
-  });
-
-  it('displays API limit error', () => {
-    // Mock API limit error
-    jest.spyOn(require('../../hooks/useWeatherData'), 'useWeatherData').mockReturnValue({
-      currentData: [],
-      forecastData: [],
-      isLoading: false,
-      error: 'API call limit reached'
+    await waitFor(() => {
+      expect(screen.getByText('Berlin')).toBeInTheDocument();
     });
 
-    render(<Page />);
-
-    expect(screen.getByText('API call limit reached. Please try again later.')).toBeInTheDocument();
+    expect(screen.getByText('OpenWeatherMap')).toBeInTheDocument();
+    expect(screen.getByText('OpenMeteo')).toBeInTheDocument();
+    expect(screen.getByText('OpenWeatherMap Temperature Forecast')).toBeInTheDocument();
   });
-}); 
+});

--- a/src/app/api/geocode/route.ts
+++ b/src/app/api/geocode/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import type { UnifiedLocation } from '@/types/unifiedWeather';
+
+interface GeocodeApiResult {
+  id?: number;
+  name: string;
+  country: string;
+  admin1?: string;
+  latitude: number;
+  longitude: number;
+  timezone?: string;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('q');
+
+  if (!query || query.trim().length < 2) {
+    return NextResponse.json({ results: [] });
+  }
+
+  try {
+    const response = await fetch(
+      `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(query)}&count=10&language=en&format=json`
+    );
+
+    if (!response.ok) {
+      throw new Error(`Geocoding request failed with status ${response.status}`);
+    }
+
+    const data = await response.json();
+    const results: UnifiedLocation[] = (data.results ?? []).map((result: GeocodeApiResult) => ({
+      id: String(result.id ?? `${result.latitude.toFixed(3)}:${result.longitude.toFixed(3)}`),
+      name: result.name,
+      admin1: result.admin1,
+      country: result.country,
+      latitude: result.latitude,
+      longitude: result.longitude,
+      timezone: result.timezone
+    }));
+
+    return NextResponse.json({ results });
+  } catch (error) {
+    console.error('Failed to fetch geocode data', error);
+    return NextResponse.json({ error: 'Failed to fetch locations' }, { status: 500 });
+  }
+}

--- a/src/app/api/weather/current/route.ts
+++ b/src/app/api/weather/current/route.ts
@@ -1,0 +1,169 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  normalizeOpenMeteoCurrent,
+  normalizeOpenWeatherCurrent
+} from '@/server/normalize';
+import { buildCacheKey, weatherCache } from '@/server/cache';
+import { weatherRateLimiter } from '@/server/rateLimiter';
+import type {
+  UnifiedCurrentProviderData,
+  UnifiedCurrentResponse,
+  UnifiedLocation,
+  WeatherProvider
+} from '@/types/unifiedWeather';
+
+const WEATHER_PROVIDERS: WeatherProvider[] = ['OpenWeatherMap', 'OpenMeteo'];
+
+const OPENWEATHER_API_KEY = process.env.OPENWEATHER_API_KEY ?? process.env.NEXT_PUBLIC_OPENWEATHER_API_KEY;
+
+async function fetchProviderData(
+  provider: WeatherProvider,
+  location: UnifiedLocation
+): Promise<{ status: number; payload: UnifiedCurrentProviderData }> {
+  const cacheKey = buildCacheKey('current', provider, location.latitude, location.longitude);
+  const canConsume = weatherRateLimiter.canConsume(provider);
+  const cached = weatherCache.get<UnifiedCurrentProviderData['data']>(cacheKey);
+
+  if (!canConsume) {
+    if (cached) {
+      return {
+        status: 429,
+        payload: {
+          provider,
+          fromCache: true,
+          rateLimited: true,
+          data: cached
+        }
+      };
+    }
+
+    return {
+      status: 429,
+      payload: {
+        provider,
+        fromCache: false,
+        rateLimited: true,
+        error: 'Daily rate limit reached'
+      }
+    };
+  }
+
+  if (cached) {
+    return {
+      status: 200,
+      payload: {
+        provider,
+        fromCache: true,
+        rateLimited: false,
+        data: cached
+      }
+    };
+  }
+
+  try {
+    weatherRateLimiter.consume(provider);
+
+    if (provider === 'OpenWeatherMap') {
+      if (!OPENWEATHER_API_KEY) {
+        throw new Error('OpenWeatherMap API key not configured');
+      }
+
+      const response = await fetch(
+        `https://api.openweathermap.org/data/2.5/weather?lat=${location.latitude}&lon=${location.longitude}&appid=${OPENWEATHER_API_KEY}&units=metric`
+      );
+
+      if (!response.ok) {
+        throw new Error(`OpenWeatherMap request failed with status ${response.status}`);
+      }
+
+      const json = await response.json();
+      const normalized = normalizeOpenWeatherCurrent(json);
+      weatherCache.set(cacheKey, normalized);
+
+      return {
+        status: 200,
+        payload: {
+          provider,
+          fromCache: false,
+          rateLimited: false,
+          data: normalized
+        }
+      };
+    }
+
+    const response = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=${location.latitude}&longitude=${location.longitude}&current=temperature_2m,relative_humidity_2m,pressure_msl,wind_speed_10m,wind_direction_10m,precipitation,cloud_cover&timezone=${encodeURIComponent(location.timezone ?? 'auto')}`
+    );
+
+    if (!response.ok) {
+      throw new Error(`Open-Meteo request failed with status ${response.status}`);
+    }
+
+    const json = await response.json();
+    const normalized = normalizeOpenMeteoCurrent(json);
+    weatherCache.set(cacheKey, normalized);
+
+    return {
+      status: 200,
+      payload: {
+        provider,
+        fromCache: false,
+        rateLimited: false,
+        data: normalized
+      }
+    };
+  } catch (error) {
+    console.error(`Failed to fetch ${provider} current weather`, error);
+    return {
+      status: 500,
+      payload: {
+        provider,
+        fromCache: false,
+        rateLimited: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    };
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const latitude = Number.parseFloat(searchParams.get('latitude') ?? '');
+  const longitude = Number.parseFloat(searchParams.get('longitude') ?? '');
+  const name = searchParams.get('name') ?? 'Unknown';
+  const country = searchParams.get('country') ?? '';
+  const admin1 = searchParams.get('admin1') ?? undefined;
+  const timezone = searchParams.get('timezone') ?? undefined;
+  const id = searchParams.get('id') ?? `${latitude},${longitude}`;
+
+  if (Number.isNaN(latitude) || Number.isNaN(longitude)) {
+    return NextResponse.json({ error: 'Invalid coordinates supplied' }, { status: 400 });
+  }
+
+  const location: UnifiedLocation = {
+    id,
+    name,
+    country,
+    admin1,
+    timezone,
+    latitude,
+    longitude
+  };
+
+  const providerResponses = await Promise.all(
+    WEATHER_PROVIDERS.map(async (provider) => fetchProviderData(provider, location))
+  );
+
+  const status = providerResponses.some((result) => result.status === 429)
+    ? 429
+    : providerResponses.some((result) => result.status >= 500)
+    ? 502
+    : 200;
+
+  const response: UnifiedCurrentResponse = {
+    location,
+    providers: providerResponses.map((result) => result.payload)
+  };
+
+  return NextResponse.json(response, { status });
+}

--- a/src/app/api/weather/forecast/route.ts
+++ b/src/app/api/weather/forecast/route.ts
@@ -1,0 +1,169 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  normalizeOpenMeteoForecast,
+  normalizeOpenWeatherForecast
+} from '@/server/normalize';
+import { buildCacheKey, weatherCache } from '@/server/cache';
+import { weatherRateLimiter } from '@/server/rateLimiter';
+import type {
+  UnifiedForecastProviderData,
+  UnifiedForecastResponse,
+  UnifiedLocation,
+  WeatherProvider
+} from '@/types/unifiedWeather';
+
+const WEATHER_PROVIDERS: WeatherProvider[] = ['OpenWeatherMap', 'OpenMeteo'];
+
+const OPENWEATHER_API_KEY = process.env.OPENWEATHER_API_KEY ?? process.env.NEXT_PUBLIC_OPENWEATHER_API_KEY;
+
+async function fetchProviderData(
+  provider: WeatherProvider,
+  location: UnifiedLocation
+): Promise<{ status: number; payload: UnifiedForecastProviderData }> {
+  const cacheKey = buildCacheKey('forecast', provider, location.latitude, location.longitude);
+  const canConsume = weatherRateLimiter.canConsume(provider);
+  const cached = weatherCache.get<UnifiedForecastProviderData['data']>(cacheKey);
+
+  if (!canConsume) {
+    if (cached) {
+      return {
+        status: 429,
+        payload: {
+          provider,
+          fromCache: true,
+          rateLimited: true,
+          data: cached
+        }
+      };
+    }
+
+    return {
+      status: 429,
+      payload: {
+        provider,
+        fromCache: false,
+        rateLimited: true,
+        error: 'Daily rate limit reached'
+      }
+    };
+  }
+
+  if (cached) {
+    return {
+      status: 200,
+      payload: {
+        provider,
+        fromCache: true,
+        rateLimited: false,
+        data: cached
+      }
+    };
+  }
+
+  try {
+    weatherRateLimiter.consume(provider);
+
+    if (provider === 'OpenWeatherMap') {
+      if (!OPENWEATHER_API_KEY) {
+        throw new Error('OpenWeatherMap API key not configured');
+      }
+
+      const response = await fetch(
+        `https://api.openweathermap.org/data/2.5/forecast?lat=${location.latitude}&lon=${location.longitude}&appid=${OPENWEATHER_API_KEY}&units=metric`
+      );
+
+      if (!response.ok) {
+        throw new Error(`OpenWeatherMap forecast failed with status ${response.status}`);
+      }
+
+      const json = await response.json();
+      const normalized = normalizeOpenWeatherForecast(json);
+      weatherCache.set(cacheKey, normalized);
+
+      return {
+        status: 200,
+        payload: {
+          provider,
+          fromCache: false,
+          rateLimited: false,
+          data: normalized
+        }
+      };
+    }
+
+    const response = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=${location.latitude}&longitude=${location.longitude}&daily=temperature_2m_max,temperature_2m_min,precipitation_probability_max,precipitation_sum,wind_speed_10m_max,wind_direction_10m_dominant&timezone=${encodeURIComponent(location.timezone ?? 'auto')}`
+    );
+
+    if (!response.ok) {
+      throw new Error(`Open-Meteo forecast failed with status ${response.status}`);
+    }
+
+    const json = await response.json();
+    const normalized = normalizeOpenMeteoForecast(json);
+    weatherCache.set(cacheKey, normalized);
+
+    return {
+      status: 200,
+      payload: {
+        provider,
+        fromCache: false,
+        rateLimited: false,
+        data: normalized
+      }
+    };
+  } catch (error) {
+    console.error(`Failed to fetch ${provider} forecast`, error);
+    return {
+      status: 500,
+      payload: {
+        provider,
+        fromCache: false,
+        rateLimited: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    };
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const latitude = Number.parseFloat(searchParams.get('latitude') ?? '');
+  const longitude = Number.parseFloat(searchParams.get('longitude') ?? '');
+  const name = searchParams.get('name') ?? 'Unknown';
+  const country = searchParams.get('country') ?? '';
+  const admin1 = searchParams.get('admin1') ?? undefined;
+  const timezone = searchParams.get('timezone') ?? undefined;
+  const id = searchParams.get('id') ?? `${latitude},${longitude}`;
+
+  if (Number.isNaN(latitude) || Number.isNaN(longitude)) {
+    return NextResponse.json({ error: 'Invalid coordinates supplied' }, { status: 400 });
+  }
+
+  const location: UnifiedLocation = {
+    id,
+    name,
+    country,
+    admin1,
+    timezone,
+    latitude,
+    longitude
+  };
+
+  const providerResponses = await Promise.all(
+    WEATHER_PROVIDERS.map(async (provider) => fetchProviderData(provider, location))
+  );
+
+  const status = providerResponses.some((result) => result.status === 429)
+    ? 429
+    : providerResponses.some((result) => result.status >= 500)
+    ? 502
+    : 200;
+
+  const response: UnifiedForecastResponse = {
+    location,
+    providers: providerResponses.map((result) => result.payload)
+  };
+
+  return NextResponse.json(response, { status });
+}

--- a/src/components/CompareBar.tsx
+++ b/src/components/CompareBar.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import type { UnifiedLocation } from '@/types/unifiedWeather';
+
+interface CompareBarProps {
+  locations: UnifiedLocation[];
+  maxSelections: number;
+  onRemove: (id: string) => void;
+}
+
+export const CompareBar = ({ locations, maxSelections, onRemove }: CompareBarProps) => {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-4 mb-6">
+      <div className="flex flex-wrap items-center gap-2">
+        <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200 uppercase tracking-wide">
+          Selected Locations ({locations.length}/{maxSelections})
+        </h2>
+        {locations.length === 0 && (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Search for a city to begin comparing weather providers.
+          </p>
+        )}
+        {locations.map((location) => (
+          <span
+            key={location.id}
+            className="inline-flex items-center gap-2 bg-blue-50 dark:bg-blue-900/40 text-blue-700 dark:text-blue-200 px-3 py-1 rounded-full text-sm"
+          >
+            {location.name}, {location.country}
+            <button
+              type="button"
+              onClick={() => onRemove(location.id)}
+              className="text-blue-700 dark:text-blue-200 hover:text-blue-900 dark:hover:text-blue-100"
+              aria-label={`Remove ${location.name} from comparison`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/FavoritesPanel.tsx
+++ b/src/components/FavoritesPanel.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import type { UnifiedLocation } from '@/types/unifiedWeather';
+
+interface FavoritesPanelProps {
+  favorites: UnifiedLocation[];
+  selectedLocations: UnifiedLocation[];
+  maxSelections: number;
+  onSelect: (location: UnifiedLocation) => void;
+  onRemove: (locationId: string) => void;
+}
+
+export const FavoritesPanel = ({ favorites, selectedLocations, maxSelections, onSelect, onRemove }: FavoritesPanelProps) => {
+  const selectedIds = new Set(selectedLocations.map((location) => location.id));
+  const disableAdditionalSelection = selectedLocations.length >= maxSelections;
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-800 dark:text-white">Favorites</h2>
+        <span className="text-sm text-gray-500 dark:text-gray-400">{favorites.length} saved</span>
+      </div>
+      {favorites.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Save locations to quickly compare them.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {favorites.map((location) => {
+            const isSelected = selectedIds.has(location.id);
+            const disableSelection = disableAdditionalSelection && !isSelected;
+
+            return (
+              <li
+                key={location.id}
+                className="flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2"
+              >
+                <div>
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {location.name}{' '}
+                    <span className="text-gray-500 dark:text-gray-400">
+                      {location.admin1 ? `${location.admin1}, ` : ''}
+                      {location.country}
+                    </span>
+                  </p>
+                  <p className="text-xs text-gray-400 dark:text-gray-500">
+                    {location.latitude.toFixed(2)}, {location.longitude.toFixed(2)}
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onRemove(location.id)}
+                    className="px-3 py-1 rounded text-sm border border-red-300 text-red-600 dark:border-red-700 dark:text-red-300"
+                  >
+                    Remove
+                  </button>
+                  <button
+                    type="button"
+                    disabled={disableSelection}
+                    onClick={() => onSelect(location)}
+                    className={`px-3 py-1 rounded text-sm text-white ${
+                      disableSelection ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700'
+                    }`}
+                  >
+                    {isSelected ? 'Selected' : 'Compare'}
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/components/SearchLocation.tsx
+++ b/src/components/SearchLocation.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { UnifiedLocation } from '@/types/unifiedWeather';
+
+interface SearchLocationProps {
+  favorites: UnifiedLocation[];
+  selectedLocations: UnifiedLocation[];
+  maxSelections: number;
+  onSelect: (location: UnifiedLocation) => void;
+  onToggleFavorite: (location: UnifiedLocation) => void;
+}
+
+export const SearchLocation = ({
+  favorites,
+  selectedLocations,
+  maxSelections,
+  onSelect,
+  onToggleFavorite
+}: SearchLocationProps) => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<UnifiedLocation[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (query.trim().length < 2) {
+      setResults([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(async () => {
+      try {
+        setLoading(true);
+        const response = await fetch(`/api/geocode?q=${encodeURIComponent(query)}`, {
+          signal: controller.signal
+        });
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error(data.error ?? 'Failed to search locations');
+        }
+
+        setResults(data.results ?? []);
+        setError(null);
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') {
+          return;
+        }
+        setError(err instanceof Error ? err.message : 'Failed to search locations');
+      } finally {
+        setLoading(false);
+      }
+    }, 300);
+
+    return () => {
+      controller.abort();
+      clearTimeout(timeout);
+    };
+  }, [query]);
+
+  const favoriteIds = useMemo(() => new Set(favorites.map((fav) => fav.id)), [favorites]);
+  const selectedIds = useMemo(() => new Set(selectedLocations.map((location) => location.id)), [selectedLocations]);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 space-y-4">
+      <div>
+        <label htmlFor="city" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Search for a city
+        </label>
+        <input
+          id="city"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Enter city name"
+          className="w-full rounded-md border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white px-3 py-2"
+        />
+      </div>
+      {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+      {loading && <p className="text-sm text-gray-500 dark:text-gray-400">Searching...</p>}
+      {results.length > 0 && (
+        <ul className="space-y-2">
+          {results.map((location) => {
+            const isFavorite = favoriteIds.has(location.id);
+            const isSelected = selectedIds.has(location.id);
+            const disableSelection = !isSelected && selectedLocations.length >= maxSelections;
+
+            return (
+              <li
+                key={location.id}
+                className="flex items-center justify-between rounded-lg border border-gray-200 dark:border-gray-700 px-3 py-2"
+              >
+                <div>
+                  <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {location.name}{' '}
+                    <span className="text-gray-500 dark:text-gray-400">
+                      {location.admin1 ? `${location.admin1}, ` : ''}
+                      {location.country}
+                    </span>
+                  </p>
+                  <p className="text-xs text-gray-400 dark:text-gray-500">
+                    {location.latitude.toFixed(2)}, {location.longitude.toFixed(2)}
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onToggleFavorite(location)}
+                    className={`px-3 py-1 rounded text-sm border transition ${
+                      isFavorite
+                        ? 'border-yellow-500 text-yellow-600 dark:text-yellow-300'
+                        : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'
+                    }`}
+                  >
+                    {isFavorite ? 'Unfavorite' : 'Favorite'}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={disableSelection}
+                    onClick={() => onSelect(location)}
+                    className={`px-3 py-1 rounded text-sm text-white ${
+                      disableSelection ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700'
+                    }`}
+                  >
+                    {isSelected ? 'Selected' : 'Compare'}
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};

--- a/src/components/WeatherCard.tsx
+++ b/src/components/WeatherCard.tsx
@@ -1,70 +1,96 @@
-import { WeatherData } from '../types/weather';
 import { format } from 'date-fns';
 import { WiDaySunny, WiRain, WiStrongWind, WiHumidity, WiBarometer, WiCloudy } from 'react-icons/wi';
+import type { UnifiedCurrentConditions, WeatherProvider } from '@/types/unifiedWeather';
 
 interface WeatherCardProps {
-  data: WeatherData;
+  provider: WeatherProvider;
+  data?: UnifiedCurrentConditions;
+  fromCache?: boolean;
+  rateLimited?: boolean;
+  error?: string;
 }
 
-export const WeatherCard = ({ data }: WeatherCardProps) => {
+export const WeatherCard = ({ provider, data, fromCache, rateLimited, error }: WeatherCardProps) => {
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6">
-      <div className="flex justify-between items-center mb-4">
-        <h2 className="text-xl font-semibold text-gray-800 dark:text-white">{data.provider}</h2>
-        <span className="text-sm text-gray-500 dark:text-gray-400">
-          {format(new Date(data.timestamp), 'HH:mm')}
-        </span>
-      </div>
-      
-      <div className="grid grid-cols-2 gap-4">
-        <div className="flex items-center space-x-2">
-          <WiDaySunny className="w-8 h-8 text-yellow-500" />
-          <div>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Temperature</p>
-            <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.temperature.toFixed(1)}°C</p>
-          </div>
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg p-6 space-y-4">
+      <div className="flex justify-between items-center">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-800 dark:text-white">{provider}</h2>
+          {data && (
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              {format(new Date(data.timestamp), 'PPpp')}
+            </span>
+          )}
         </div>
-        
-        <div className="flex items-center space-x-2">
-          <WiRain className="w-8 h-8 text-blue-500" />
-          <div>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Precipitation</p>
-            <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.precipitation}mm</p>
-          </div>
-        </div>
-        
-        <div className="flex items-center space-x-2">
-          <WiStrongWind className="w-8 h-8 text-gray-500" />
-          <div>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Wind Speed</p>
-            <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.windSpeed.toFixed(1)}m/s</p>
-          </div>
-        </div>
-        
-        <div className="flex items-center space-x-2">
-          <WiHumidity className="w-8 h-8 text-blue-400" />
-          <div>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Humidity</p>
-            <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.humidity}%</p>
-          </div>
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <WiBarometer className="w-8 h-8 text-purple-500" />
-          <div>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Pressure</p>
-            <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.pressure}hPa</p>
-          </div>
-        </div>
-
-        <div className="flex items-center space-x-2">
-          <WiCloudy className="w-8 h-8 text-gray-400" />
-          <div>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Cloud Cover</p>
-            <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.cloudCover}%</p>
-          </div>
+        <div className="flex gap-2">
+          {fromCache && (
+            <span className="text-xs font-semibold uppercase text-yellow-600 bg-yellow-100 dark:bg-yellow-900/30 dark:text-yellow-200 px-2 py-1 rounded">
+              Cached
+            </span>
+          )}
+          {rateLimited && (
+            <span className="text-xs font-semibold uppercase text-red-600 bg-red-100 dark:bg-red-900/30 dark:text-red-300 px-2 py-1 rounded">
+              Rate limited
+            </span>
+          )}
         </div>
       </div>
+
+      {error ? (
+        <div className="text-red-600 dark:text-red-400">{error}</div>
+      ) : data ? (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="flex items-center space-x-2">
+            <WiDaySunny className="w-8 h-8 text-yellow-500" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Temperature</p>
+              <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.temperature.toFixed(1)}°C</p>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <WiRain className="w-8 h-8 text-blue-500" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Precipitation</p>
+              <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.precipitation.toFixed(1)}mm</p>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <WiStrongWind className="w-8 h-8 text-gray-500" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Wind Speed</p>
+              <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.windSpeed.toFixed(1)}m/s</p>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <WiHumidity className="w-8 h-8 text-blue-400" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Humidity</p>
+              <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.humidity}%</p>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <WiBarometer className="w-8 h-8 text-purple-500" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Pressure</p>
+              <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.pressure}hPa</p>
+            </div>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <WiCloudy className="w-8 h-8 text-gray-400" />
+            <div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Cloud Cover</p>
+              <p className="text-2xl font-bold text-gray-800 dark:text-white">{data.cloudCover}%</p>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="text-gray-500 dark:text-gray-400">No data available</div>
+      )}
     </div>
   );
 };

--- a/src/components/WeatherChart.tsx
+++ b/src/components/WeatherChart.tsx
@@ -1,13 +1,17 @@
+'use client';
+
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, BarChart, Bar } from 'recharts';
-import { ChartDataPoint, CurrentWeatherChartData, PrecipitationChartData } from '../utils/weatherDataTransformers';
 import { useTheme } from 'next-themes';
+import { ChartDataPoint, PrecipitationChartData } from '@/utils/weatherDataTransformers';
 
 interface WeatherChartProps {
   title: string;
   type: 'line' | 'bar';
-  data: ChartDataPoint[] | CurrentWeatherChartData[] | PrecipitationChartData[];
+  data: ChartDataPoint[] | PrecipitationChartData[];
   className?: string;
 }
+
+const BAR_COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042'];
 
 export const WeatherChart = ({ title, type, data, className = '' }: WeatherChartProps) => {
   const { theme } = useTheme();
@@ -26,64 +30,60 @@ export const WeatherChart = ({ title, type, data, className = '' }: WeatherChart
     );
   }
 
+  const barSeriesKeys =
+    type === 'bar'
+      ? Array.from(
+          new Set(
+            (data as PrecipitationChartData[]).flatMap((item) =>
+              Object.keys(item).filter((key) => key !== 'date')
+            )
+          )
+        )
+      : [];
+
   return (
     <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 ${className}`}>
       <h2 className="text-xl font-semibold text-gray-800 dark:text-white mb-4">{title}</h2>
       <div className="h-64">
         <ResponsiveContainer width="100%" height="100%">
           {type === 'line' ? (
-            <LineChart data={data}>
+            <LineChart data={data as ChartDataPoint[]}>
               <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
-              <XAxis 
-                dataKey="date" 
-                stroke={textColor}
-                tick={{ fill: textColor }}
-              />
-              <YAxis 
-                stroke={textColor}
-                tick={{ fill: textColor }}
-              />
-              <Tooltip 
-                contentStyle={{ 
+              <XAxis dataKey="date" stroke={textColor} tick={{ fill: textColor }} />
+              <YAxis stroke={textColor} tick={{ fill: textColor }} />
+              <Tooltip
+                contentStyle={{
                   backgroundColor,
                   border: `1px solid ${gridColor}`,
                   color: textColor
                 }}
               />
-              <Legend 
-                wrapperStyle={{ color: textColor }}
-              />
+              <Legend wrapperStyle={{ color: textColor }} />
               <Line type="monotone" dataKey="minTemp" stroke="#0088fe" name="Min Temperature (°C)" />
               <Line type="monotone" dataKey="maxTemp" stroke="#ff7300" name="Max Temperature (°C)" />
             </LineChart>
           ) : (
-            <BarChart data={data}>
+            <BarChart data={data as PrecipitationChartData[]}>
               <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
-              <XAxis 
-                dataKey="date" 
-                stroke={textColor}
-                tick={{ fill: textColor }}
-              />
-              <YAxis 
-                stroke={textColor}
-                tick={{ fill: textColor }}
-              />
-              <Tooltip 
-                contentStyle={{ 
+              <XAxis dataKey="date" stroke={textColor} tick={{ fill: textColor }} />
+              <YAxis stroke={textColor} tick={{ fill: textColor }} />
+              <Tooltip
+                contentStyle={{
                   backgroundColor,
                   border: `1px solid ${gridColor}`,
                   color: textColor
                 }}
               />
-              <Legend 
-                wrapperStyle={{ color: textColor }}
-              />
-              <Bar dataKey="OpenMeteo" fill="#8884d8" name="OpenMeteo (mm)" />
-              <Bar dataKey="OpenWeatherMap" fill="#82ca9d" name="OpenWeather (mm)" />
+              <Legend wrapperStyle={{ color: textColor }} />
+              {barSeriesKeys.map((key, index) => (
+                <Bar key={key} dataKey={key} fill={BAR_COLORS[index % BAR_COLORS.length]} name={`${key} (mm)`} />
+              ))}
             </BarChart>
           )}
         </ResponsiveContainer>
       </div>
     </div>
   );
-}; 
+};
+
+export default WeatherChart;

--- a/src/components/__tests__/WeatherCard.test.tsx
+++ b/src/components/__tests__/WeatherCard.test.tsx
@@ -1,51 +1,48 @@
 import { render, screen } from '@testing-library/react';
 import WeatherCard from '../WeatherCard';
+import type { UnifiedCurrentConditions } from '@/types/unifiedWeather';
 
 describe('WeatherCard', () => {
-  const mockWeatherData = {
-    provider: 'OpenMeteo',
+  const baseData: UnifiedCurrentConditions = {
+    timestamp: '2024-01-01T12:00:00Z',
     temperature: 20,
     humidity: 60,
-    windSpeed: 5,
-    precipitation: 0,
     pressure: 1013,
+    windSpeed: 5,
+    windDirection: 180,
+    precipitation: 0,
     cloudCover: 20
   };
 
-  it('renders weather card with all data', () => {
-    render(<WeatherCard {...mockWeatherData} />);
-    
-    // Check if provider name is displayed
+  it('renders weather metrics for provider', () => {
+    render(
+      <WeatherCard
+        provider="OpenMeteo"
+        data={baseData}
+        fromCache
+        rateLimited={false}
+      />
+    );
+
     expect(screen.getByText('OpenMeteo')).toBeInTheDocument();
-    
-    // Check if temperature is displayed
-    expect(screen.getByText('20°C')).toBeInTheDocument();
-    
-    // Check if other weather metrics are displayed
-    expect(screen.getByText('60%')).toBeInTheDocument(); // Humidity
-    expect(screen.getByText('5 m/s')).toBeInTheDocument(); // Wind Speed
-    expect(screen.getByText('0 mm')).toBeInTheDocument(); // Precipitation
-    expect(screen.getByText('1013 hPa')).toBeInTheDocument(); // Pressure
-    expect(screen.getByText('20%')).toBeInTheDocument(); // Cloud Cover
+    expect(screen.getByText('20.0°C')).toBeInTheDocument();
+    expect(screen.getByText('0.0mm')).toBeInTheDocument();
+    expect(screen.getByText('5.0m/s')).toBeInTheDocument();
+    expect(screen.getByText('60%')).toBeInTheDocument();
+    expect(screen.getByText('1013hPa')).toBeInTheDocument();
+    expect(screen.getByText('20%')).toBeInTheDocument();
+    expect(screen.getByText('Cached')).toBeInTheDocument();
   });
 
-  it('renders weather card with missing optional data', () => {
-    const minimalData = {
-      provider: 'OpenMeteo',
-      temperature: 20,
-      humidity: 60,
-      windSpeed: 5,
-      precipitation: 0
-    };
+  it('renders error state when provided', () => {
+    render(
+      <WeatherCard
+        provider="OpenWeatherMap"
+        error="Failed to load"
+      />
+    );
 
-    render(<WeatherCard {...minimalData} />);
-    
-    // Check if required data is displayed
-    expect(screen.getByText('OpenMeteo')).toBeInTheDocument();
-    expect(screen.getByText('20°C')).toBeInTheDocument();
-    
-    // Check if optional data is not displayed
-    expect(screen.queryByText('hPa')).not.toBeInTheDocument();
-    expect(screen.queryByText('%')).not.toBeInTheDocument();
+    expect(screen.getByText('Failed to load')).toBeInTheDocument();
+    expect(screen.getByText('OpenWeatherMap')).toBeInTheDocument();
   });
-}); 
+});

--- a/src/components/__tests__/WeatherChart.test.tsx
+++ b/src/components/__tests__/WeatherChart.test.tsx
@@ -13,55 +13,21 @@ describe('WeatherChart', () => {
   ];
 
   it('renders line chart with temperature data', () => {
-    render(
-      <WeatherChart
-        type="line"
-        data={mockLineChartData}
-        title="Temperature Forecast"
-        xAxisKey="date"
-        yAxisKey="maxTemp"
-      />
-    );
+    render(<WeatherChart type="line" data={mockLineChartData} title="Temperature Forecast" />);
 
-    // Check if chart title is displayed
     expect(screen.getByText('Temperature Forecast')).toBeInTheDocument();
-    
-    // Check if chart container is rendered
-    expect(screen.getByRole('img')).toBeInTheDocument();
   });
 
   it('renders bar chart with precipitation data', () => {
-    render(
-      <WeatherChart
-        type="bar"
-        data={mockBarChartData}
-        title="Precipitation Forecast"
-        xAxisKey="date"
-        yAxisKey="OpenMeteo"
-      />
-    );
+    render(<WeatherChart type="bar" data={mockBarChartData} title="Precipitation Forecast" />);
 
-    // Check if chart title is displayed
     expect(screen.getByText('Precipitation Forecast')).toBeInTheDocument();
-    
-    // Check if chart container is rendered
-    expect(screen.getByRole('img')).toBeInTheDocument();
   });
 
-  it('renders with custom height', () => {
-    const customHeight = 400;
-    render(
-      <WeatherChart
-        type="line"
-        data={mockLineChartData}
-        title="Temperature Forecast"
-        xAxisKey="date"
-        yAxisKey="maxTemp"
-        height={customHeight}
-      />
-    );
+  it('renders empty state when no data provided', () => {
+    render(<WeatherChart type="line" data={[]} title="No Data" />);
 
-    const chartContainer = screen.getByRole('img');
-    expect(chartContainer).toHaveStyle(`height: ${customHeight}px`);
+    expect(screen.getByText('No Data')).toBeInTheDocument();
+    expect(screen.getByText('No data available')).toBeInTheDocument();
   });
-}); 
+});

--- a/src/hooks/useUnifiedWeather.ts
+++ b/src/hooks/useUnifiedWeather.ts
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  UnifiedCurrentResponse,
+  UnifiedForecastResponse,
+  UnifiedLocation
+} from '@/types/unifiedWeather';
+
+interface UseUnifiedWeatherResult {
+  current: Record<string, UnifiedCurrentResponse>;
+  forecast: Record<string, UnifiedForecastResponse>;
+  loading: boolean;
+  errors: Record<string, string | null>;
+  rateLimited: boolean;
+  refetch: () => Promise<void>;
+}
+
+const buildSearchParams = (location: UnifiedLocation) => {
+  const params = new URLSearchParams({
+    latitude: location.latitude.toString(),
+    longitude: location.longitude.toString(),
+    name: location.name,
+    country: location.country,
+    id: location.id
+  });
+
+  if (location.admin1) {
+    params.set('admin1', location.admin1);
+  }
+
+  if (location.timezone) {
+    params.set('timezone', location.timezone);
+  }
+
+  return params;
+};
+
+export const useUnifiedWeather = (locations: UnifiedLocation[]): UseUnifiedWeatherResult => {
+  const [current, setCurrent] = useState<Record<string, UnifiedCurrentResponse>>({});
+  const [forecast, setForecast] = useState<Record<string, UnifiedForecastResponse>>({});
+  const [errors, setErrors] = useState<Record<string, string | null>>({});
+  const [loading, setLoading] = useState(false);
+  const [rateLimited, setRateLimited] = useState(false);
+  const fetchIdRef = useRef(0);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const fetchWeather = useCallback(async () => {
+    const fetchId = ++fetchIdRef.current;
+
+    if (locations.length === 0) {
+      if (!isMountedRef.current || fetchId !== fetchIdRef.current) {
+        return;
+      }
+      setCurrent({});
+      setForecast({});
+      setErrors({});
+      setRateLimited(false);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const responses = await Promise.all(
+        locations.map(async (location) => {
+          const params = buildSearchParams(location);
+          const [currentResponse, forecastResponse] = await Promise.all([
+            fetch(`/api/weather/current?${params.toString()}`),
+            fetch(`/api/weather/forecast?${params.toString()}`)
+          ]);
+
+          const currentJson = await currentResponse.json();
+          const forecastJson = await forecastResponse.json();
+
+          return {
+            location,
+            currentResponse,
+            forecastResponse,
+            currentJson: currentJson as UnifiedCurrentResponse & { error?: string },
+            forecastJson: forecastJson as UnifiedForecastResponse & { error?: string }
+          };
+        })
+      );
+
+      if (!isMountedRef.current || fetchId !== fetchIdRef.current) {
+        return;
+      }
+
+      const nextCurrent: Record<string, UnifiedCurrentResponse> = {};
+      const nextForecast: Record<string, UnifiedForecastResponse> = {};
+      const nextErrors: Record<string, string | null> = {};
+      let encounteredRateLimit = false;
+
+      responses.forEach(({ location, currentResponse, forecastResponse, currentJson, forecastJson }) => {
+        nextCurrent[location.id] = currentJson;
+        nextForecast[location.id] = forecastJson;
+
+        const currentError = !currentResponse.ok && currentResponse.status !== 429 ? currentJson.error ?? 'Failed to load current weather' : null;
+        const forecastError = !forecastResponse.ok && forecastResponse.status !== 429 ? forecastJson.error ?? 'Failed to load forecast' : null;
+
+        nextErrors[location.id] = currentError ?? forecastError;
+
+        if (
+          currentResponse.status === 429 ||
+          forecastResponse.status === 429 ||
+          currentJson.providers?.some?.((provider) => provider.rateLimited) ||
+          forecastJson.providers?.some?.((provider) => provider.rateLimited)
+        ) {
+          encounteredRateLimit = true;
+        }
+      });
+
+      setCurrent(nextCurrent);
+      setForecast(nextForecast);
+      setErrors(nextErrors);
+      setRateLimited(encounteredRateLimit);
+    } catch (error) {
+      if (!isMountedRef.current || fetchId !== fetchIdRef.current) {
+        return;
+      }
+
+      const fallbackErrors: Record<string, string | null> = {};
+      locations.forEach((location) => {
+        fallbackErrors[location.id] = error instanceof Error ? error.message : 'Failed to fetch weather data';
+      });
+      setErrors(fallbackErrors);
+      setRateLimited(false);
+    } finally {
+      if (isMountedRef.current && fetchId === fetchIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [locations]);
+
+  useEffect(() => {
+    fetchWeather();
+  }, [fetchWeather]);
+
+  return {
+    current,
+    forecast,
+    loading,
+    errors,
+    rateLimited,
+    refetch: fetchWeather
+  };
+};

--- a/src/server/__tests__/cache.test.ts
+++ b/src/server/__tests__/cache.test.ts
@@ -1,0 +1,22 @@
+import { TTLCache } from '../cache';
+
+describe('TTLCache', () => {
+  it('stores and retrieves values within the TTL', () => {
+    const cache = new TTLCache(1000);
+    cache.set('test', 'value');
+    expect(cache.get<string>('test')).toBe('value');
+  });
+
+  it('expires values after TTL duration', () => {
+    jest.useFakeTimers();
+    const cache = new TTLCache(1000);
+
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    cache.set('test', 'value');
+
+    jest.setSystemTime(new Date('2024-01-01T00:00:02Z'));
+    expect(cache.get<string>('test')).toBeUndefined();
+
+    jest.useRealTimers();
+  });
+});

--- a/src/server/__tests__/normalize.test.ts
+++ b/src/server/__tests__/normalize.test.ts
@@ -1,0 +1,83 @@
+import {
+  normalizeOpenMeteoCurrent,
+  normalizeOpenMeteoForecast,
+  normalizeOpenWeatherCurrent,
+  normalizeOpenWeatherForecast
+} from '../normalize';
+
+describe('normalize utilities', () => {
+  it('normalizes OpenWeather current response', () => {
+    const normalized = normalizeOpenWeatherCurrent({
+      dt: 1700000000,
+      main: { temp: 10, humidity: 70, pressure: 1005 },
+      wind: { speed: 3, deg: 200 },
+      rain: { '1h': 1 },
+      clouds: { all: 50 }
+    });
+
+    expect(normalized.temperature).toBe(10);
+    expect(normalized.precipitation).toBe(1);
+    expect(normalized.windDirection).toBe(200);
+  });
+
+  it('normalizes Open-Meteo current response', () => {
+    const normalized = normalizeOpenMeteoCurrent({
+      current: {
+        time: '2024-01-01T00:00:00Z',
+        temperature_2m: 12,
+        relative_humidity_2m: 65,
+        pressure_msl: 1010,
+        wind_speed_10m: 4,
+        wind_direction_10m: 210,
+        precipitation: 0.4,
+        cloud_cover: 60
+      }
+    });
+
+    expect(normalized.temperature).toBe(12);
+    expect(normalized.cloudCover).toBe(60);
+  });
+
+  it('normalizes OpenWeather forecast response', () => {
+    const normalized = normalizeOpenWeatherForecast({
+      list: [
+        {
+          dt_txt: '2024-01-02 00:00:00',
+          main: { temp: 10 },
+          wind: { speed: 3, deg: 200 },
+          rain: { '3h': 0.1 },
+          pop: 0.2
+        },
+        {
+          dt_txt: '2024-01-02 03:00:00',
+          main: { temp: 12 },
+          wind: { speed: 4, deg: 210 },
+          rain: { '3h': 0.2 },
+          pop: 0.5
+        }
+      ]
+    });
+
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0].maxTemperature).toBe(12);
+    expect(normalized[0].precipitationAmount).toBeCloseTo(0.3);
+    expect(normalized[0].precipitationProbability).toBe(50);
+  });
+
+  it('normalizes Open-Meteo forecast response', () => {
+    const normalized = normalizeOpenMeteoForecast({
+      daily: {
+        time: ['2024-01-02'],
+        temperature_2m_max: [15],
+        temperature_2m_min: [7],
+        precipitation_probability_max: [40],
+        precipitation_sum: [2],
+        wind_speed_10m_max: [6],
+        wind_direction_10m_dominant: [190]
+      }
+    });
+
+    expect(normalized[0].maxTemperature).toBe(15);
+    expect(normalized[0].precipitationAmount).toBe(2);
+  });
+});

--- a/src/server/__tests__/rateLimiter.test.ts
+++ b/src/server/__tests__/rateLimiter.test.ts
@@ -1,0 +1,27 @@
+import { DailyRateLimiter } from '../rateLimiter';
+
+describe('DailyRateLimiter', () => {
+  it('enforces limits per provider', () => {
+    const limiter = new DailyRateLimiter(2);
+    expect(limiter.canConsume('OpenWeatherMap')).toBe(true);
+    limiter.consume('OpenWeatherMap');
+    expect(limiter.getRemaining('OpenWeatherMap')).toBe(1);
+    limiter.consume('OpenWeatherMap');
+    expect(limiter.canConsume('OpenWeatherMap')).toBe(false);
+    expect(() => limiter.consume('OpenWeatherMap')).toThrow('Rate limit reached');
+  });
+
+  it('resets counters on new day', () => {
+    jest.useFakeTimers();
+    const limiter = new DailyRateLimiter(1);
+
+    jest.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    expect(limiter.canConsume('OpenMeteo')).toBe(true);
+    limiter.consume('OpenMeteo');
+    expect(limiter.canConsume('OpenMeteo')).toBe(false);
+
+    jest.setSystemTime(new Date('2024-01-02T00:00:00Z'));
+    expect(limiter.canConsume('OpenMeteo')).toBe(true);
+    jest.useRealTimers();
+  });
+});

--- a/src/server/cache.ts
+++ b/src/server/cache.ts
@@ -1,0 +1,54 @@
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+export class TTLCache {
+  private cache = new Map<string, CacheEntry<unknown>>();
+
+  constructor(private defaultTtlMs = 10 * 60 * 1000) {}
+
+  get<T>(key: string): T | undefined {
+    const entry = this.cache.get(key);
+    if (!entry) {
+      return undefined;
+    }
+
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+
+    return entry.value as T;
+  }
+
+  set<T>(key: string, value: T, ttlMs = this.defaultTtlMs) {
+    this.cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+  }
+
+  delete(key: string) {
+    this.cache.delete(key);
+  }
+
+  clearExpired() {
+    const now = Date.now();
+    for (const [key, entry] of this.cache.entries()) {
+      if (entry.expiresAt <= now) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+}
+
+export const weatherCache = new TTLCache();
+
+export const buildCacheKey = (
+  type: 'current' | 'forecast',
+  provider: string,
+  latitude: number,
+  longitude: number
+) => `${type}:${provider}:${latitude.toFixed(3)}:${longitude.toFixed(3)}`;

--- a/src/server/normalize.ts
+++ b/src/server/normalize.ts
@@ -1,0 +1,136 @@
+import { UnifiedCurrentConditions, UnifiedForecastDay } from '@/types/unifiedWeather';
+
+type OpenWeatherCurrentResponse = {
+  dt: number;
+  main: {
+    temp: number;
+    humidity: number;
+    pressure: number;
+  };
+  wind: {
+    speed: number;
+    deg: number;
+  };
+  rain?: {
+    '1h'?: number;
+  };
+  clouds?: {
+    all: number;
+  };
+};
+
+type OpenMeteoCurrentResponse = {
+  current: {
+    time: string;
+    temperature_2m: number;
+    relative_humidity_2m: number;
+    pressure_msl: number;
+    wind_speed_10m: number;
+    wind_direction_10m: number;
+    precipitation: number;
+    cloud_cover: number;
+  };
+};
+
+type OpenWeatherForecastResponse = {
+  list: Array<{
+    dt_txt: string;
+    main: {
+      temp: number;
+    };
+    wind: {
+      speed: number;
+      deg: number;
+    };
+    rain?: {
+      '3h'?: number;
+    };
+    pop: number;
+  }>;
+};
+
+type OpenMeteoForecastResponse = {
+  daily: {
+    time: string[];
+    temperature_2m_max: number[];
+    temperature_2m_min: number[];
+    precipitation_probability_max: number[];
+    precipitation_sum: number[];
+    wind_speed_10m_max: number[];
+    wind_direction_10m_dominant: number[];
+  };
+};
+
+export const normalizeOpenWeatherCurrent = (data: OpenWeatherCurrentResponse): UnifiedCurrentConditions => ({
+  timestamp: new Date(data.dt * 1000).toISOString(),
+  temperature: data.main.temp,
+  humidity: data.main.humidity,
+  pressure: data.main.pressure,
+  windSpeed: data.wind.speed,
+  windDirection: data.wind.deg,
+  precipitation: data.rain?.['1h'] ?? 0,
+  cloudCover: data.clouds?.all ?? 0
+});
+
+export const normalizeOpenMeteoCurrent = (data: OpenMeteoCurrentResponse): UnifiedCurrentConditions => ({
+  timestamp: data.current.time,
+  temperature: data.current.temperature_2m,
+  humidity: data.current.relative_humidity_2m,
+  pressure: data.current.pressure_msl,
+  windSpeed: data.current.wind_speed_10m,
+  windDirection: data.current.wind_direction_10m,
+  precipitation: data.current.precipitation,
+  cloudCover: data.current.cloud_cover
+});
+
+export const normalizeOpenWeatherForecast = (data: OpenWeatherForecastResponse): UnifiedForecastDay[] => {
+  const grouped = data.list.reduce<Record<string, {
+    temps: number[];
+    precipitation: number[];
+    precipitationProbability: number[];
+    windSpeeds: number[];
+    windDirections: number[];
+  }>>((acc, entry) => {
+    const date = entry.dt_txt.split(' ')[0];
+    if (!acc[date]) {
+      acc[date] = {
+        temps: [],
+        precipitation: [],
+        precipitationProbability: [],
+        windSpeeds: [],
+        windDirections: []
+      };
+    }
+
+    acc[date].temps.push(entry.main.temp);
+    acc[date].precipitation.push(entry.rain?.['3h'] ?? 0);
+    acc[date].precipitationProbability.push(entry.pop * 100);
+    acc[date].windSpeeds.push(entry.wind.speed);
+    acc[date].windDirections.push(entry.wind.deg);
+    return acc;
+  }, {});
+
+  return Object.entries(grouped).map(([date, values]) => {
+    const dominantWindIndex = Math.floor(values.windDirections.length / 2);
+    return {
+      date,
+      maxTemperature: Math.max(...values.temps),
+      minTemperature: Math.min(...values.temps),
+      precipitationProbability: Math.max(...values.precipitationProbability),
+      precipitationAmount: values.precipitation.reduce((sum, value) => sum + value, 0),
+      windSpeed: Math.max(...values.windSpeeds),
+      windDirection: values.windDirections[dominantWindIndex] ?? 0
+    };
+  });
+};
+
+export const normalizeOpenMeteoForecast = (data: OpenMeteoForecastResponse): UnifiedForecastDay[] =>
+  data.daily.time.map((time, index) => ({
+    date: time,
+    maxTemperature: data.daily.temperature_2m_max[index],
+    minTemperature: data.daily.temperature_2m_min[index],
+    precipitationProbability: data.daily.precipitation_probability_max[index],
+    precipitationAmount: data.daily.precipitation_sum[index],
+    windSpeed: data.daily.wind_speed_10m_max[index],
+    windDirection: data.daily.wind_direction_10m_dominant[index]
+  }));

--- a/src/server/rateLimiter.ts
+++ b/src/server/rateLimiter.ts
@@ -1,0 +1,52 @@
+interface RateEntry {
+  date: string;
+  count: number;
+}
+
+export class DailyRateLimiter {
+  private readonly counters = new Map<string, RateEntry>();
+
+  constructor(private readonly limit: number) {}
+
+  private getToday(): string {
+    return new Date().toISOString().split('T')[0];
+  }
+
+  private getEntry(key: string): RateEntry {
+    const today = this.getToday();
+    const entry = this.counters.get(key);
+
+    if (!entry || entry.date !== today) {
+      const freshEntry = { date: today, count: 0 };
+      this.counters.set(key, freshEntry);
+      return freshEntry;
+    }
+
+    return entry;
+  }
+
+  canConsume(key: string): boolean {
+    const entry = this.getEntry(key);
+    return entry.count < this.limit;
+  }
+
+  consume(key: string) {
+    const entry = this.getEntry(key);
+    if (entry.count >= this.limit) {
+      throw new Error('Rate limit reached');
+    }
+    entry.count += 1;
+    this.counters.set(key, entry);
+  }
+
+  getRemaining(key: string): number {
+    const entry = this.getEntry(key);
+    return Math.max(this.limit - entry.count, 0);
+  }
+
+  reset() {
+    this.counters.clear();
+  }
+}
+
+export const weatherRateLimiter = new DailyRateLimiter(500);

--- a/src/types/unifiedWeather.ts
+++ b/src/types/unifiedWeather.ts
@@ -1,0 +1,58 @@
+export type WeatherProvider = 'OpenWeatherMap' | 'OpenMeteo';
+
+export interface UnifiedLocation {
+  id: string;
+  name: string;
+  admin1?: string;
+  country: string;
+  latitude: number;
+  longitude: number;
+  timezone?: string;
+}
+
+export interface UnifiedCurrentConditions {
+  timestamp: string;
+  temperature: number;
+  humidity: number;
+  pressure: number;
+  windSpeed: number;
+  windDirection: number;
+  precipitation: number;
+  cloudCover: number;
+}
+
+export interface UnifiedCurrentProviderData {
+  provider: WeatherProvider;
+  fromCache: boolean;
+  rateLimited: boolean;
+  data?: UnifiedCurrentConditions;
+  error?: string;
+}
+
+export interface UnifiedCurrentResponse {
+  location: UnifiedLocation;
+  providers: UnifiedCurrentProviderData[];
+}
+
+export interface UnifiedForecastDay {
+  date: string;
+  maxTemperature: number;
+  minTemperature: number;
+  precipitationProbability: number;
+  precipitationAmount: number;
+  windSpeed: number;
+  windDirection: number;
+}
+
+export interface UnifiedForecastProviderData {
+  provider: WeatherProvider;
+  fromCache: boolean;
+  rateLimited: boolean;
+  data?: UnifiedForecastDay[];
+  error?: string;
+}
+
+export interface UnifiedForecastResponse {
+  location: UnifiedLocation;
+  providers: UnifiedForecastProviderData[];
+}

--- a/src/utils/weatherDataTransformers.ts
+++ b/src/utils/weatherDataTransformers.ts
@@ -1,5 +1,5 @@
-import { WeatherData, WeatherForecast } from '../types/weather';
 import { format } from 'date-fns';
+import { UnifiedForecastDay, UnifiedForecastProviderData } from '@/types/unifiedWeather';
 
 export interface ChartDataPoint {
   date: string;
@@ -7,58 +7,38 @@ export interface ChartDataPoint {
   minTemp: number;
 }
 
-export interface CurrentWeatherChartData {
-  provider: string;
-  temperature: number;
-  humidity: number;
-  windSpeed: number;
-  precipitation: number;
-}
-
 export interface PrecipitationChartData {
   date: string;
   [key: string]: string | number;
 }
 
-export const transformCurrentWeatherData = (data: WeatherData[]): CurrentWeatherChartData[] => {
-  return data.map(item => ({
-    provider: item.provider,
-    temperature: item.temperature,
-    humidity: item.humidity,
-    windSpeed: item.windSpeed,
-    precipitation: item.precipitation,
-  }));
-};
-
-export const transformForecastData = (forecasts: WeatherForecast[]): Record<string, WeatherForecast[]> => {
-  return forecasts.reduce((acc, forecast) => {
-    if (!acc[forecast.provider]) acc[forecast.provider] = [];
-    acc[forecast.provider].push(forecast);
-    return acc;
-  }, {} as Record<string, WeatherForecast[]>);
-};
-
-export const transformForecastToChartData = (forecasts: WeatherForecast[]): ChartDataPoint[] => {
-  return forecasts.map(forecast => ({
+export const transformForecastToChartData = (forecasts: UnifiedForecastDay[]): ChartDataPoint[] =>
+  forecasts.map((forecast) => ({
     date: format(new Date(forecast.date), 'MMM dd'),
-    maxTemp: forecast.maxTemperature,
-    minTemp: forecast.minTemperature,
+    maxTemp: Number(forecast.maxTemperature.toFixed(1)),
+    minTemp: Number(forecast.minTemperature.toFixed(1))
   }));
-};
 
-export const transformPrecipitationData = (forecasts: WeatherForecast[]): PrecipitationChartData[] => {
-  return forecasts.reduce((acc: PrecipitationChartData[], forecast) => {
-    const date = format(new Date(forecast.date), 'MMM dd');
-    const existingDay = acc.find(item => item.date === date);
-    
-    if (existingDay) {
-      existingDay[forecast.provider] = forecast.precipitationAmount;
-    } else {
-      acc.push({
-        date,
-        [forecast.provider]: forecast.precipitationAmount,
-      });
+export const transformPrecipitationData = (
+  providers: UnifiedForecastProviderData[]
+): PrecipitationChartData[] => {
+  const aggregate = new Map<string, PrecipitationChartData>();
+
+  providers.forEach((provider) => {
+    if (!provider.data) {
+      return;
     }
-    return acc;
-  }, []);
-}; 
+
+    provider.data.forEach((forecast) => {
+      const date = format(new Date(forecast.date), 'MMM dd');
+      if (!aggregate.has(date)) {
+        aggregate.set(date, { date });
+      }
+
+      const existing = aggregate.get(date)!;
+      existing[provider.provider] = Number(forecast.precipitationAmount.toFixed(2));
+    });
+  });
+
+  return Array.from(aggregate.values());
+};


### PR DESCRIPTION
## Summary
- add unified weather types with shared cache, rate limiter, and normalization utilities
- expose geocode and unified weather API routes backed by OpenWeatherMap and Open-Meteo with caching and rate limiting
- implement location search, favorites, and comparison UI powered by a new unified weather hook and updated charts/tests

## Testing
- `npm test -- --runInBand` *(fails: Jest binary missing because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8e090885883279f0efebd99e27328